### PR TITLE
Support no bridge ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An opinionated declarative docker composition tool with runtime dependencies bet
 
 ## What's new
 
+* 2016-06-03 Made not finding docker0 non fatal (with warnings) and in the process it looks like mac support *might* be working...!
 * 2016-06-02 Added support for volumes local to directory containing `grua.yaml`
 
 ## Installation
@@ -522,6 +523,9 @@ Currently only supports two 'subcommands':
 * _BRIDGE_IP_
 
 Replace the template with the IP address of the docker bridge.
+
+_Important note: if grua can't find the docker0 interface, you will get a 
+warning at startup, and this expansion won't work._
 
 ```
 skydock:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An opinionated declarative docker composition tool with runtime dependencies bet
 
 ## What's new
 
-* 2016-06-03 Made not finding docker0 non fatal (with warnings) and in the process it looks like mac support *might* be working...!
+* 2016-06-03 Made not finding docker0 non fatal (with warnings) 
 * 2016-06-02 Added support for volumes local to directory containing `grua.yaml`
 
 ## Installation

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,7 +25,7 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
-        sys.stderr.write( ">> " + msg + "\n")
+        sys.stderr.write(">> " + msg + "\n")
 
 
 def quietcall(command):
@@ -37,7 +37,23 @@ def quietcall(command):
         call(command)
 
 
+#############
+
+
+cached_bridge_ip = None
+
+
 def find_bridge_ip():
+    global cached_bridge_ip
+
+    if cached_bridge_ip is not None:
+        return cached_bridge_ip
+    else:
+        cached_bridge_ip = find_bridge_ip_impl()
+        return cached_bridge_ip
+
+
+def find_bridge_ip_impl():
 
     done = False
     output = ""
@@ -81,6 +97,9 @@ def find_bridge_ip():
             raise Exception(output + " is not a valid IP address for BridgeIP")
 
     return output
+
+
+#####
 
 
 def touch(fname, times=None):

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,9 +25,7 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
-    if mem.Mode['noisy'] == 'noisy' or ignore_quiet:
-        if not mem.quiet:
-            sys.stderr.write( ">> " + msg + "\n")
+        sys.stderr.write( ">> " + msg + "\n")
 
 
 def quietcall(command):

--- a/grua/util.py
+++ b/grua/util.py
@@ -44,14 +44,9 @@ def find_bridge_ip():
         done = True
 
     except OSError as e:
-        # if e.errno == os.errno.ENOENT:
-        #     # handle file not found error.
-        #     print "File not found"
-        #     done = False
-        # else:
-        #     # Something else went wrong
-        #     raise
-        print ("WARN: Could not use 'ip addr | grep inet' to find bridge ip")
+        print ("WARN: OSError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
+    except subprocess.CalledProcessError as e:
+        print ("WARN: CalledProcessError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
 
     if not done:
         try:
@@ -62,7 +57,9 @@ def find_bridge_ip():
             output = subprocess.check_output(('grep', 'inet'), stdin=sp.stdout).strip().split(':')[1].split()[0]
 
         except OSError as e:
-            print("WARN: Could not use 'ifconfig to find bridge ip")
+            print("WARN: OSError Could not use 'ifconfig to find bridge ip " + e.message)
+        except subprocess.CalledProcessError as e:
+            print("WARN: CalledProcessError Could not use 'ifconfig to find bridge ip " + e.message)
 
     if not done:
         print("WARN: Continuing without support for BRIDGE_IP expansion")

--- a/grua/util.py
+++ b/grua/util.py
@@ -2,6 +2,7 @@ import subprocess
 from subprocess import call
 import os
 import re
+from warnings import showwarning
 from mem import mem
 
 
@@ -43,13 +44,14 @@ def find_bridge_ip():
         done = True
 
     except OSError as e:
-        if e.errno == os.errno.ENOENT:
-            # handle file not found error.
-            print "File not found"
-            done = False
-        else:
-            # Something else went wrong
-            raise
+        # if e.errno == os.errno.ENOENT:
+        #     # handle file not found error.
+        #     print "File not found"
+        #     done = False
+        # else:
+        #     # Something else went wrong
+        #     raise
+        showwarning("Could not use 'ip addr | grep inet' to find bridge ip")
 
     if not done:
         try:
@@ -60,14 +62,10 @@ def find_bridge_ip():
             output = subprocess.check_output(('grep', 'inet'), stdin=sp.stdout).strip().split(':')[1].split()[0]
 
         except OSError as e:
-            if e.errno == os.errno.ENOENT:
-                # handle file not found error.
-                done = False
-            else:
-                raise
+            showwarning("Could not use 'ifconfig to find bridge ip")
 
     if not done:
-        raise Exception("Could not find either 'ip' or 'ifconfig' in PATH")
+        showwarning("Continuing without support for BRIDGE_IP expansion")
 
     sp.wait()
 

--- a/grua/util.py
+++ b/grua/util.py
@@ -35,6 +35,8 @@ def quietcall(command):
 def find_bridge_ip():
 
     done = False
+    output = ""
+    
     try:
         command = ["ip", "addr", "show", "dev", "docker0"]
         sp = subprocess.Popen(command, stdout=subprocess.PIPE)

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,7 +25,7 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
-    sys.stderr.write( ">> " + msg)
+    sys.stderr.write( ">> " + msg + "\n")
 
 
 def quietcall(command):

--- a/grua/util.py
+++ b/grua/util.py
@@ -51,9 +51,9 @@ def find_bridge_ip():
         done = True
 
     except OSError as e:
-        warn ("WARN: OSError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
+        pass
     except subprocess.CalledProcessError as e:
-        warn ("WARN: CalledProcessError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
+        pass
 
     if not done:
         try:
@@ -64,9 +64,9 @@ def find_bridge_ip():
             output = subprocess.check_output(('grep', 'inet'), stdin=sp.stdout).strip().split(':')[1].split()[0]
 
         except OSError as e:
-            warn("WARN: OSError Could not use 'ifconfig to find bridge ip " + e.message)
+            pass
         except subprocess.CalledProcessError as e:
-            warn("WARN: CalledProcessError Could not use 'ifconfig to find bridge ip " + e.message)
+            pass
 
     sp.wait()
 

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,7 +25,6 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
-    if not mem.quiet:
         sys.stderr.write( ">> " + msg)
 
 
@@ -72,7 +71,7 @@ def find_bridge_ip():
     sp.wait()
 
     if not done:
-        warn("WARN: Continuing without support for BRIDGE_IP expansion")
+        warnq("WARN: Continuing without support for BRIDGE_IP expansion")
 
     else:
         # ensure we have a valid ip

--- a/grua/util.py
+++ b/grua/util.py
@@ -37,23 +37,7 @@ def quietcall(command):
         call(command)
 
 
-#############
-
-
-cached_bridge_ip = None
-
-
 def find_bridge_ip():
-    global cached_bridge_ip
-
-    if cached_bridge_ip is not None:
-        return cached_bridge_ip
-    else:
-        cached_bridge_ip = find_bridge_ip_impl()
-        return cached_bridge_ip
-
-
-def find_bridge_ip_impl():
 
     done = False
     output = ""
@@ -97,9 +81,6 @@ def find_bridge_ip_impl():
             raise Exception(output + " is not a valid IP address for BridgeIP")
 
     return output
-
-
-#####
 
 
 def touch(fname, times=None):

--- a/grua/util.py
+++ b/grua/util.py
@@ -2,6 +2,7 @@ import subprocess
 from subprocess import call
 import os
 import re
+import sys
 from mem import mem
 
 
@@ -21,6 +22,11 @@ def note(msg, ignore_quiet=False):
     if mem.Mode['noisy'] == 'noisy' or ignore_quiet:
         if not mem.quiet:
             print "> " + msg
+
+
+def warn(msg):
+    if not mem.quiet:
+        sys.stderr.write( ">> " + msg)
 
 
 def quietcall(command):
@@ -46,9 +52,9 @@ def find_bridge_ip():
         done = True
 
     except OSError as e:
-        print ("WARN: OSError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
+        warn ("WARN: OSError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
     except subprocess.CalledProcessError as e:
-        print ("WARN: CalledProcessError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
+        warn ("WARN: CalledProcessError Could not use 'ip addr | grep inet' to find bridge ip " + e.message)
 
     if not done:
         try:
@@ -59,14 +65,14 @@ def find_bridge_ip():
             output = subprocess.check_output(('grep', 'inet'), stdin=sp.stdout).strip().split(':')[1].split()[0]
 
         except OSError as e:
-            print("WARN: OSError Could not use 'ifconfig to find bridge ip " + e.message)
+            warn("WARN: OSError Could not use 'ifconfig to find bridge ip " + e.message)
         except subprocess.CalledProcessError as e:
-            print("WARN: CalledProcessError Could not use 'ifconfig to find bridge ip " + e.message)
+            warn("WARN: CalledProcessError Could not use 'ifconfig to find bridge ip " + e.message)
 
     sp.wait()
 
     if not done:
-        print("WARN: Continuing without support for BRIDGE_IP expansion")
+        warn("WARN: Continuing without support for BRIDGE_IP expansion")
 
     else:
         # ensure we have a valid ip

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,7 +25,9 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
-    sys.stderr.write( ">> " + msg + "\n")
+    if mem.Mode['noisy'] == 'noisy' or ignore_quiet:
+        if not mem.quiet:
+            sys.stderr.write( ">> " + msg + "\n")
 
 
 def quietcall(command):

--- a/grua/util.py
+++ b/grua/util.py
@@ -34,6 +34,7 @@ def quietcall(command):
 
 def find_bridge_ip():
 
+    done = False
     try:
         command = ["ip", "addr", "show", "dev", "docker0"]
         sp = subprocess.Popen(command, stdout=subprocess.PIPE)

--- a/grua/util.py
+++ b/grua/util.py
@@ -36,7 +36,7 @@ def find_bridge_ip():
 
     done = False
     output = ""
-    
+
     try:
         command = ["ip", "addr", "show", "dev", "docker0"]
         sp = subprocess.Popen(command, stdout=subprocess.PIPE)
@@ -63,16 +63,17 @@ def find_bridge_ip():
         except subprocess.CalledProcessError as e:
             print("WARN: CalledProcessError Could not use 'ifconfig to find bridge ip " + e.message)
 
+    sp.wait()
+
     if not done:
         print("WARN: Continuing without support for BRIDGE_IP expansion")
 
-    sp.wait()
-
-    # ensure we have a valid ip
-    p = re.compile(
-            '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')
-    if not p.match(output):
-        raise Exception(output + " is not a valid IP address for BridgeIP")
+    else:
+        # ensure we have a valid ip
+        p = re.compile(
+                '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')
+        if not p.match(output):
+            raise Exception(output + " is not a valid IP address for BridgeIP")
 
     return output
 

--- a/grua/util.py
+++ b/grua/util.py
@@ -2,7 +2,6 @@ import subprocess
 from subprocess import call
 import os
 import re
-from warnings import showwarning
 from mem import mem
 
 
@@ -51,7 +50,7 @@ def find_bridge_ip():
         # else:
         #     # Something else went wrong
         #     raise
-        showwarning("Could not use 'ip addr | grep inet' to find bridge ip")
+        print ("WARN: Could not use 'ip addr | grep inet' to find bridge ip")
 
     if not done:
         try:
@@ -62,10 +61,10 @@ def find_bridge_ip():
             output = subprocess.check_output(('grep', 'inet'), stdin=sp.stdout).strip().split(':')[1].split()[0]
 
         except OSError as e:
-            showwarning("Could not use 'ifconfig to find bridge ip")
+            print("WARN: Could not use 'ifconfig to find bridge ip")
 
     if not done:
-        showwarning("Continuing without support for BRIDGE_IP expansion")
+        print("WARN: Continuing without support for BRIDGE_IP expansion")
 
     sp.wait()
 

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,8 +25,7 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
-    if not mem.quiet:
-        sys.stderr.write( ">> " + msg)
+    sys.stderr.write( ">> " + msg)
 
 
 def quietcall(command):

--- a/grua/util.py
+++ b/grua/util.py
@@ -25,6 +25,7 @@ def note(msg, ignore_quiet=False):
 
 
 def warn(msg):
+    if not mem.quiet:
         sys.stderr.write( ">> " + msg)
 
 
@@ -71,7 +72,7 @@ def find_bridge_ip():
     sp.wait()
 
     if not done:
-        warnq("WARN: Continuing without support for BRIDGE_IP expansion")
+        warn("WARN: Continuing without support for BRIDGE_IP expansion")
 
     else:
         # ensure we have a valid ip


### PR DESCRIPTION
Stop grua throwing exceptions if docker0 interface not found. Now it will issue a warning, and any attempt to use BRIDGE_IP expansion will get an empty string back.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marsbard/grua/11)

<!-- Reviewable:end -->
